### PR TITLE
Assign Upptime outage issues to tradmusica for email notifications

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.7
+# 🔼 Upptime @v1.41.8
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.7
+# 🔼 Upptime @v1.41.8
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.7
+# 🔼 Upptime @v1.41.8
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -33,20 +33,20 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "readme"
         env:
@@ -57,7 +57,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.7
+# 🔼 Upptime @v1.41.8
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.7
+# 🔼 Upptime @v1.41.8
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "readme"
         env:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.7
+# 🔼 Upptime @v1.41.8
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.7
+# 🔼 Upptime @v1.41.8
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.7
+# 🔼 Upptime @v1.41.8
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@v1.41.8
         with:
           command: "update"
         env:

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -120,3 +120,6 @@ status-website:
 
 # Upptime also supports notifications, assigning issues, and more
 # See https://upptime.js.org/docs/configuration
+assignees:
+  - tradmusica
+


### PR DESCRIPTION
### Motivation
- Ensure newly opened Upptime incident issues are assigned to `tradmusica` so GitHub can deliver email notifications for outages when notifications are enabled.

### Description
- Add `assignees: - tradmusica` to `.upptimerc.yml` as a configuration-only change.

### Testing
- Verified the update and commit with `git diff -- .upptimerc.yml`, `git add .upptimerc.yml && git commit -m "Configure Upptime outage issues with assignee for email alerts"`, and inspected the file with `nl -ba .upptimerc.yml | tail -n 20`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a36cbdc08325beaabbb5b9426ce6)